### PR TITLE
Dodanie kolumny czasu wydania puszki do widoku przeliczonych puszek

### DIFF
--- a/client/src/pages/countedBoxes/BoxesApprovedPage/BoxesForApprovalPage.tsx
+++ b/client/src/pages/countedBoxes/BoxesApprovedPage/BoxesForApprovalPage.tsx
@@ -86,6 +86,13 @@ export const BoxesForApprovalPage = () => {
       width: 40,
     },
     {
+      titleName: 'Godz. wydania',
+      keyName: 'give_hour',
+      sortType: 'time',
+      width: 60,
+      search: true,
+    },
+    {
       titleName: 'Godz. przeliczenia',
       keyName: 'time_counted',
       sortType: 'time',

--- a/client/src/utils/Functions/createRefactorData.ts
+++ b/client/src/utils/Functions/createRefactorData.ts
@@ -25,6 +25,7 @@ export const createDisplayableData = (data: IBoxes[]) => {
       amount_PLN: item.amount_PLN,
       comment: item.comment,
       countingStation: item.counting_user_id > 3 ? item.counting_user_id - 3 : null,
+      give_hour: new Date(item.time_given).toLocaleTimeString(),
       time_counted: new Date(item.time_counted).toLocaleTimeString(),
     });
   }


### PR DESCRIPTION
Resolves #239 
Dodano kolumnę z godziną wydania puszki dla tabel w widoku `liczymy/countedBoxes`. 
![obraz](https://github.com/user-attachments/assets/4e89921a-f41f-40b4-b06b-e6b36394b13d)
