### PR TITLE
Załatać RBAC w API

### DIFF
--- a/server/app/Http/Controllers/Api/RatesApiController.php
+++ b/server/app/Http/Controllers/Api/RatesApiController.php
@@ -94,9 +94,9 @@ final class RatesApiController extends ApiController
         $rates = $fetcher->fetchRates();
         return json_encode([
             'rates' => [
-                'EUR' => $rates['EUR'],
-                'USD' => $rates['USD'],
-                'GBP' => $rates['GBP'],
+                'EUR' => (float) $rates['EUR'],
+                'USD' => (float) $rates['USD'],
+                'GBP' => (float) $rates['GBP'],
             ]
         ]);
     }

--- a/server/app/Http/Controllers/CharityBoxController.php
+++ b/server/app/Http/Controllers/CharityBoxController.php
@@ -4,14 +4,8 @@ namespace App\Http\Controllers;
 
 use App\BoxEvent;
 use App\CharityBox;
-use App\Events\BoxConfirmed;
 use App\Lib\BoxOperator\BoxOperator;
-use Auth;
 use Illuminate\Http\Request;
-use Money\Money;
-use Money\Currencies\ISOCurrencies;
-use Money\Formatter\DecimalMoneyFormatter;
-use Illuminate\Support\Facades\Log;
 use Carbon\Carbon;
 
 class CharityBoxController extends Controller
@@ -21,6 +15,10 @@ class CharityBoxController extends Controller
     {
         //Zabezpieczamy autoryzacją (każdy zalogowany użytkownik ma dostęp)
         $this->middleware('auth');
+
+        $this->middleware('admin')->only(
+            ['getVerifyList', 'getVerify', 'postVerify', 'getList', 'getListAway', 'getModify', 'postModify']
+        );
     }
 
     //Dodaj nową puszkę (formularz)

--- a/server/app/helpers.php
+++ b/server/app/helpers.php
@@ -29,11 +29,11 @@ function totalCollectedArray() {
 
     //Zliczamy Inne waluty
     //EUR
-    $amount_EUR = CharityBox::where('is_confirmed', '=', 1)->sum('amount_EUR');
+    $amount_EUR = round(CharityBox::where('is_confirmed', '=', 1)->sum('amount_EUR'), 2);
     //USD
-    $amount_USD = CharityBox::where('is_confirmed', '=', 1)->sum('amount_USD');
+    $amount_USD = round(CharityBox::where('is_confirmed', '=', 1)->sum('amount_USD'), 2);
     //GBP
-    $amount_GBP = CharityBox::where('is_confirmed', '=', 1)->sum('amount_GBP');
+    $amount_GBP = round(CharityBox::where('is_confirmed', '=', 1)->sum('amount_GBP'), 2);
 
     //Pobieranie kursu
     $fetcher = resolveRatesFetcher();

--- a/server/tests/Feature/Api/Stats/StatsTest.php
+++ b/server/tests/Feature/Api/Stats/StatsTest.php
@@ -15,12 +15,15 @@ test('as a volounteer I can get stats', function () {
     $response->assertJson(fn (AssertableJson $json) =>
     $json->whereType('rates', 'array')
         ->whereAllType([
-            'amount_PLN' => 'string',
-            'amount_EUR' => 'string',
-            'amount_GBP' => 'string',
-            'amount_USD' => 'string',
-            'amount_total_in_PLN' => 'string',
-            'collectors_in_city' => 'integer',
+                'amount_PLN' => ['double', 'integer'],
+                'amount_PLN_unconfirmed' => ['double', 'integer'],
+                'amount_PLN_eskarbonka' => ['double', 'integer'],
+                'amount_EUR' => ['double', 'integer'],
+                'amount_GBP' => ['double', 'integer'],
+                'amount_USD' => ['double', 'integer'],
+                'rates' => 'array',
+                'amount_total_in_PLN' => ['double', 'integer'],
+                'collectors_in_city' => 'integer',
         ])
     );
 


### PR DESCRIPTION
Closes #211 

Dodałem sprawdzanie roli na endpointach, które tego wymagały. Naprawiłem też błędne typy zwracanych wartości przy kurasach walut (np. PLN były zwracane we float'cie, a EUR i USD w stringu, itp.).

Jeżeli coś można poprawić to dajcie znać. Też sorki za krótkie (tygodniowe 💀) opóźnienie.